### PR TITLE
Add JuliaC trim compile workload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches: [main]
     tags: ["*"]
-
 permissions:
   contents: write
   pull-requests: read
-
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches: [main]
     tags: ["*"]
+
 permissions:
   contents: write
   pull-requests: read
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Figgy"
 uuid = "937e9308-674a-48ca-a404-047094c8c902"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Figgy.jl
+++ b/src/Figgy.jl
@@ -212,13 +212,17 @@ See [`Figgy.kmap`](@ref) and [`Figgy.select`](@ref) for helper functions to tran
 function load!(store::Store, sources...; name::String="", log::Bool=true)
     # first we load configs from all sources
     # *not* replacing figs we've already seen
-    figs = Dict{String, Tuple{Any, FigSource}}()
+    seen = Set{String}()
+    figs = Pair{String, Tuple{Any, FigSource}}[]
     for source in sources
         if source isa FigSource
             for (k, v) in load(source)
-                if !haskey(figs, k)
+                key = string(k)
+                if !(key in seen)
                     log && @info "loading config property `$k` from `$(typeof(source))`"
-                    figs[string(k)] = (v, source)
+                    push!(seen, key)
+                    entry = Pair{String, Tuple{Any, FigSource}}(key, (v, source))
+                    push!(figs, entry)
                 end
             end
         else
@@ -227,9 +231,12 @@ function load!(store::Store, sources...; name::String="", log::Bool=true)
             # Note: we don't call load here because if you're providing some generic object
             # it needs to iterate key-value configs directly
             for (k, v) in _pairs(source)
-                if !haskey(figs, k)
+                key = string(k)
+                if !(key in seen)
                     log && @info "loading config property `$k` from `$(typeof(src))`"
-                    figs[string(k)] = (v, src)
+                    push!(seen, key)
+                    entry = Pair{String, Tuple{Any, FigSource}}(key, (v, src))
+                    push!(figs, entry)
                 end
             end
         end
@@ -247,9 +254,9 @@ end
 
 # FigSources
 # helper transforms
-struct KeyMap{T} <: FigSource
+struct KeyMap{T, M} <: FigSource
     source::T # any key-value iterator/result of Figgy.load
-    mapping::Any # Function or Dict{String} w/ vals of String or Function
+    mapping::M # Function or Dict{String} w/ vals of String or Function
     select::Bool
 end
 
@@ -270,31 +277,38 @@ The `select` keyword argument indicates that only provided key mappings should b
 config source, thus combining the functionaltiy of [`Figgy.select`](@ref).
 """
 function kmap end
+
 kmap(source, mappings::Pair{String}...; select::Bool=false) = KeyMap(source, Dict(mappings), select)
 kmap(source, mappings::Union{Function, Dict{String}}; select::Bool=false) = KeyMap(source, mappings, select)
 load(x::KeyMap) = x
 
-Base.IteratorSize(::Type{KeyMap{T}}) where {T} = Base.IteratorSize(T)
+Base.IteratorSize(::Type{KeyMap{T, M}}) where {T, M} = Base.IteratorSize(T)
 Base.length(x::KeyMap) = length(x.source)
 
 Base.iterate(x::KeyMap) = _iterate(x, load(x.source))
 Base.iterate(x::KeyMap, (source, st)) = _iterate(x, source, st)
+_keymap_selected(mapping::Function, key) = true
+_keymap_selected(mapping, key) = haskey(mapping, key)
+_keymap_value(mapping::Function, key) = mapping(key)
+_keymap_value(mapping, key) = get(mapping, key, key)
+_keymap_key(key, key2::Function) = key2(key)
+_keymap_key(key, key2) = key === key2 ? key : key2
 function _iterate(x::KeyMap, source, st...)
     state = iterate(source, st...)
     state === nothing && return nothing
     kv, stt = state
     key = kv[1]
-    if x.select && !haskey(x.mapping, key)
+    if x.select && !_keymap_selected(x.mapping, key)
         return _iterate(x, source, stt)
     end
-    key2 = x.mapping isa Function ? x.mapping(key) : get(x.mapping, key, key)
-    kv2 = (key2 isa Function ? key2(key) : key === key2 ? key : key2) => kv[2]
+    key2 = _keymap_value(x.mapping, key)
+    kv2 = _keymap_key(key, key2) => kv[2]
     return kv2, (source, stt)
 end
 
-struct Select{T} <: FigSource
+struct Select{T, S} <: FigSource
     source::T # any key-value iterator/result of Figgy.load
-    set::Any # Function or Set{String}
+    set::S # Function or Set{String}
 end
 
 """
@@ -311,18 +325,18 @@ select(source, keys::String...) = Select(source, Set(keys))
 select(source, filt) = Select(source, filt)
 load(x::Select) = x
 
-Base.IteratorSize(::Type{Select{T}}) where {T} = Base.IteratorSize(T)
+Base.IteratorSize(::Type{Select{T, S}}) where {T, S} = Base.IteratorSize(T)
 Base.length(x::Select) = length(x.source)
 
 Base.iterate(x::Select) = _iterate(x, load(x.source))
 Base.iterate(x::Select, (source, st)) = _iterate(x, source, st)
+_selected(set::Set, key) = key in set
+_selected(f::Function, key) = f(key)
 function _iterate(x::Select, source, st...)
     state = iterate(source, st...)
     state === nothing && return nothing
     kv, stt = state
-    if x.set isa Set && !(kv[1] in x.set)
-        return _iterate(x, source, stt)
-    elseif x.set isa Function && !(x.set(kv[1]))
+    if !_selected(x.set, kv[1])
         return _iterate(x, source, stt)
     end
     return kv, (source, stt)

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -88,12 +88,12 @@ end
 # convenience interface for parsing a specific section of an INI file
 # returning key-values of that section
 function load(ini::IniFile)
-    io = isfile(ini.file) ? open(ini.file) : IOBuffer(ini.file)
+    contents = isfile(ini.file) ? read(ini.file, String) : ini.file
     section = ini.section
     figs = Dict{String, String}()
     section = "[$section]"
     insection = false
-    for line in eachline(io)
+    for line in split(contents, '\n')
         line = strip(line)
         if insection
             if startswith(line, "#") || startswith(line, ";") || line == ""
@@ -259,7 +259,7 @@ function JsonObject(json::Union{AbstractString, AbstractVector{UInt8}}, path::St
     pos, root = readvalue(buf, pos, len, b)
     if !isempty(path)
         for key in split(path, '.')
-            root = root[key]
+            root = root[key]::Dict{String, Any}
         end
     end
     return JsonObject(root)
@@ -304,7 +304,7 @@ function XmlObject(xml::Union{AbstractString, AbstractVector{UInt8}}, path::Stri
     pos, (rootkey, root) = readxml(buf, pos, len, b)
     if !isempty(path)
         for key in split(path, '.')
-            root = root[key]
+            root = root[key]::Dict{String, Any}
         end
     end
     return XmlObject(root)
@@ -397,7 +397,7 @@ function TomlObject(file::String, path="")
     end
     if !isempty(path)
         for key in split(path, '.')
-            figs = figs[key]
+            figs = figs[key]::Dict{String, Any}
         end
     end
     return TomlObject(figs)

--- a/test/figgy_trim_safe.jl
+++ b/test/figgy_trim_safe.jl
@@ -1,0 +1,115 @@
+using Figgy
+
+function _trim_assert(condition::Bool, msg::AbstractString)::Nothing
+    condition || error(msg)
+    return nothing
+end
+
+function _trim_load_store()::Figgy.Store
+    store = Figgy.Store()
+    Figgy.load!(
+        store,
+        Figgy.kmap(
+            Dict("raw_host" => "db.internal", "raw_port" => "5432"),
+            "raw_host" => "host",
+            "raw_port" => "port",
+        );
+        log = false,
+    )
+    Figgy.load!(
+        store,
+        Figgy.select(
+            Dict("feature" => "enabled", "ignored" => "nope"),
+            key -> key == "feature",
+        );
+        log = false,
+    )
+    Figgy.load!(
+        store,
+        Figgy.ProgramArguments("p"; args = ["--mode=test", "-p8443", "-abc", "positional"]);
+        log = false,
+    )
+    return store
+end
+
+function _trim_load_document_sources(store::Figgy.Store)::Nothing
+    ini = """
+    [default]
+    region = us-west-2
+    retries: 3
+    [other]
+    region = us-east-1
+    """
+    Figgy.load!(store, Figgy.IniFile(ini, "default"); log = false)
+
+    json = """
+    {
+        "service": {
+            "url": "https://example.invalid",
+            "enabled": true,
+            "count": 2
+        },
+        "unused": "ignored"
+    }
+    """
+    Figgy.load!(store, Figgy.JsonObject(json, "service"); log = false)
+
+    xml = """
+    <root>
+        <database>
+            <username>figgy</username>
+            <password>secret</password>
+        </database>
+    </root>
+    """
+    Figgy.load!(store, Figgy.XmlObject(xml, "database"); log = false)
+
+    toml = """
+    [limits]
+    timeout = 30
+    burst = 4
+    """
+    Figgy.load!(store, Figgy.TomlObject(toml, "limits"); log = false)
+    return nothing
+end
+
+function run_figgy_trim_sample()::Nothing
+    store = _trim_load_store()
+    _trim_load_document_sources(store)
+
+    _trim_assert((store["host"]::String) == "db.internal", "kmap host")
+    _trim_assert((store["port"]::String) == "5432", "kmap port")
+    _trim_assert((store["feature"]::String) == "enabled", "select feature")
+    _trim_assert(!haskey(store, "ignored"), "select ignored")
+    _trim_assert((store["mode"]::String) == "test", "program long option")
+    _trim_assert((store["p"]::String) == "8443", "program required value")
+    _trim_assert((store["a"]::String) == "true", "program flag a")
+    _trim_assert((store["b"]::String) == "true", "program flag b")
+    _trim_assert((store["c"]::String) == "true", "program flag c")
+    _trim_assert((store["region"]::String) == "us-west-2", "ini section")
+    _trim_assert((store["retries"]::String) == "3", "ini colon")
+    _trim_assert((store["url"]::String) == "https://example.invalid", "json string")
+    _trim_assert((store["enabled"]::String) == "true", "json bool")
+    _trim_assert((store["count"]::String) == "2", "json number")
+    _trim_assert((store["username"]::String) == "figgy", "xml username")
+    _trim_assert((store["password"]::String) == "secret", "xml password")
+    _trim_assert((store["timeout"]::Int) == 30, "toml timeout")
+    _trim_assert((store["burst"]::Int) == 4, "toml burst")
+
+    fig = Figgy.getfig(store, "host")
+    _trim_assert((fig[]::String) == "db.internal", "getfig")
+    _trim_assert((get(store, "missing", "fallback")::String) == "fallback", "get fallback")
+    delete!(store, "password")
+    _trim_assert(!haskey(store, "password"), "delete")
+    empty!(store)
+    _trim_assert(!haskey(store, "host"), "empty")
+    return nothing
+end
+
+function @main(args::Vector{String})::Cint
+    _ = args
+    run_figgy_trim_sample()
+    return 0
+end
+
+Base.Experimental.entrypoint(main, (Vector{String},))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,3 +239,5 @@ end
 end
 
 end # @testset "Figgy"
+
+include("trim_compile_tests.jl")

--- a/test/trim_compile_tests.jl
+++ b/test/trim_compile_tests.jl
@@ -1,0 +1,200 @@
+using Test
+
+const _TRIM_SAFE_ERROR_BUDGET = 0
+const _TRIM_SUPPORTED = VERSION >= v"1.12.0-rc1"
+const _TRIM_PRE_RELEASE = !isempty(VERSION.prerelease)
+const _TRIM_COMPILE_TIMEOUT_S = Sys.iswindows() ? 600.0 : 120.0
+const _TRIM_EXECUTABLE_TIMEOUT_S = Sys.iswindows() ? 120.0 : 30.0
+const _TRIM_USE_BUNDLE = Sys.iswindows()
+const _JULIAC_ENTRYPOINT_EXPR = "using JuliaC; if isdefined(JuliaC, :main); JuliaC.main(ARGS); else JuliaC._main_cli(ARGS); end"
+
+# Pkg.test() sets JULIA_LOAD_PATH restrictively, which prevents subprocesses
+# from finding stdlib packages like Pkg. Remove it so subprocesses get the
+# default load path.
+function _clean_cmd(cmd::Cmd)
+    env = Dict{String,String}(k => v for (k, v) in ENV if k != "JULIA_LOAD_PATH")
+    return setenv(cmd, env)
+end
+
+function _setup_trim_env()
+    figgy_path = normpath(joinpath(@__DIR__, ".."))
+    env_path = mktempdir()
+    julia = joinpath(Sys.BINDIR, Base.julia_exename())
+    setup_script = joinpath(env_path, "setup.jl")
+    write(setup_script, """
+    import Pkg
+    Pkg.develop(path=$(repr(figgy_path)))
+    Pkg.add("JuliaC")
+    """)
+    println("[trim] setting up temp environment with JuliaC...")
+    flush(stdout)
+    exit_code, output, timed_out = _run_command_with_timeout(
+        _clean_cmd(`$julia --startup-file=no --history-file=no --project=$env_path $setup_script`);
+        timeout_s = 120.0,
+        log_label = "setup",
+    )
+    rm(setup_script; force = true)
+    if exit_code != 0 || timed_out
+        println("[trim] setup FAILED (exit=$exit_code, timed_out=$timed_out)")
+        println(output)
+        error("failed to set up trim test environment")
+    end
+    println("[trim] temp environment ready")
+    return env_path
+end
+
+function _run_trim_compile(project_path::String, script_path::String, output_name::String; timeout_s::Float64 = _TRIM_COMPILE_TIMEOUT_S, bundle_dir::Union{Nothing, String} = nothing)
+    julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
+    cmd = if bundle_dir === nothing
+        _clean_cmd(`$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --project=$project_path --experimental --trim=safe $script_path`)
+    else
+        _clean_cmd(`$julia_exe --startup-file=no --history-file=no --code-coverage=none --project=$project_path -e $(_JULIAC_ENTRYPOINT_EXPR) -- --output-exe $output_name --bundle $bundle_dir --project=$project_path --experimental --trim=safe $script_path`)
+    end
+    return _run_command_with_timeout(cmd; timeout_s = timeout_s, log_label = "compile")
+end
+
+function _run_command_with_timeout(cmd::Cmd; timeout_s::Float64, log_label::String)
+    output_path = tempname()
+    out = open(output_path, "w")
+    exit_code = -1
+    timed_out = false
+    try
+        proc = run(pipeline(ignorestatus(cmd), stdout = out, stderr = out); wait = false)
+        timed_out = _wait_process_with_timeout!(proc; timeout_s = timeout_s, log_label = log_label)
+        exit_code = something(proc.exitcode, -1)
+    finally
+        close(out)
+    end
+    output = try
+        read(output_path, String)
+    catch
+        ""
+    finally
+        rm(output_path; force = true)
+    end
+    return exit_code, output, timed_out
+end
+
+function _wait_process_with_timeout!(proc::Base.Process; timeout_s::Float64, log_label::String)
+    started_at = time()
+    next_log_at = started_at + 10.0
+    timed_out = false
+    while Base.process_running(proc)
+        now = time()
+        if now - started_at >= timeout_s
+            timed_out = true
+            try
+                kill(proc)
+            catch
+            end
+            break
+        end
+        if now >= next_log_at
+            elapsed = round(now - started_at; digits = 1)
+            println("[trim] $(log_label) WAIT $(elapsed)s")
+            flush(stdout)
+            next_log_at = now + 10.0
+        end
+        sleep(0.1)
+    end
+    try
+        wait(proc)
+    catch
+    end
+    return timed_out
+end
+
+function _parse_trim_verify_totals(output::String)
+    m = match(r"Trim verify finished with\s+(\d+)\s+errors,\s+(\d+)\s+warnings\.", output)
+    m === nothing && return nothing
+    return parse(Int, m.captures[1]), parse(Int, m.captures[2])
+end
+
+function _count_trim_verify_messages(output::String)::Tuple{Int, Int}
+    errors = length(collect(eachmatch(r"Verifier error #\d+:", output)))
+    warnings = length(collect(eachmatch(r"Verifier warning #\d+:", output)))
+    return errors, warnings
+end
+
+function _run_trim_case(project_path::String, script_file::String, output_name::String)
+    script_path = joinpath(@__DIR__, script_file)
+    @test isfile(script_path)
+    println("[trim] compile START $(script_file)")
+    start_t = time()
+    mktempdir() do tmpdir
+        cd(tmpdir) do
+            bundle_dir = _TRIM_USE_BUNDLE ? joinpath(tmpdir, "bundle") : nothing
+            exit_code, output, timed_out = _run_trim_compile(project_path, script_path, output_name; bundle_dir = bundle_dir)
+            if timed_out
+                println("[trim] compile TIMED OUT for $(script_file)")
+                println(output)
+                @test false
+                return nothing
+            end
+            totals = _parse_trim_verify_totals(output)
+            trim_errors, trim_warnings = if totals === nothing
+                fallback = _count_trim_verify_messages(output)
+                if exit_code == 0 && fallback == (0, 0)
+                    fallback
+                elseif fallback != (0, 0)
+                    fallback
+                else
+                    error("failed to parse trim verifier summary:\n$output")
+                end
+            else
+                totals
+            end
+            if trim_errors > 0 || trim_warnings > 0
+                println("---- trim compile output ($(script_file)) ----")
+                println(output)
+                println("---- end output ----")
+            end
+            @test trim_errors <= _TRIM_SAFE_ERROR_BUDGET
+            @test trim_warnings == 0
+            output_path = Sys.iswindows() ? "$(output_name).exe" : output_name
+            if trim_errors == 0
+                run_path = bundle_dir === nothing ? output_path : joinpath(bundle_dir, "bin", output_path)
+                @test exit_code == 0
+                @test isfile(run_path)
+                run_cmd = `$(abspath(run_path))`
+                run_exit, run_output, run_timed_out = _run_command_with_timeout(run_cmd; timeout_s = _TRIM_EXECUTABLE_TIMEOUT_S, log_label = "run")
+                if run_timed_out
+                    println("[trim] executable TIMED OUT for $(script_file)")
+                    println(run_output)
+                end
+                if run_exit != 0
+                    println("---- trim executable output ($(script_file)) ----")
+                    println(run_output)
+                    println("---- end output ----")
+                end
+                @test !run_timed_out
+                @test run_exit == 0
+            else
+                @test exit_code != 0
+            end
+        end
+    end
+    println("[trim] compile DONE $(script_file) ($(round(time() - start_t; digits = 2))s)")
+    return nothing
+end
+
+@testset "Trim compile" begin
+    if Sys.WORD_SIZE != 64
+        println("[trim] skip non-64-bit Julia: JuliaC trim compilation is only exercised on 64-bit platforms")
+        @test true
+    elseif !_TRIM_SUPPORTED
+        println("[trim] skip Julia < 1.12: JuliaC trim compilation is unavailable")
+        @test true
+    elseif _TRIM_PRE_RELEASE
+        println("[trim] skip prerelease Julia: trim verifier behavior is not stable yet")
+        @test true
+    else
+        project_path = _setup_trim_env()
+        trim_workloads = [
+            ("figgy_trim_safe.jl", "figgy_trim_safe"),
+        ]
+        for (script_file, output_name) in trim_workloads
+            _run_trim_case(project_path, script_file, output_name)
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add a JuliaC `--trim=safe` compile-and-run workload for Figgy's core public config APIs
- wire the trim workload into the normal test suite with version/platform skips instead of env-var gates
- tighten key normalization and helper type parameters so the workload compiles with zero trim verifier errors
- attach the existing `kmap` docs to a generic function binding so Documenter stays clean
- bump `Project.toml` to `v1.1.2` for the next release after `v1.1.1`

## Verification
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()' && julia --project=docs docs/make.jl`
- `git diff --check`
- GitHub Actions CI run `28470092109` passed all Julia and Documentation checks
- GitHub Actions trim log shows `compile DONE figgy_trim_safe.jl` and `Trim compile | 7 7` with no verifier output

Co-authored by Codex
