### PR TITLE
Grant TagBot workflow contents:write so it can create release tags

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,6 +8,19 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      deployments: read
+      issues: read
+      discussions: read
+      packages: read
+      pages: read
+      pull-requests: read
+      repository-projects: read
+      security-events: read
+      statuses: read
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:


### PR DESCRIPTION
Every TagBot run since the v1.1.1/v1.1.2 registrations has failed with:

> Release creation blocked: token lacks required permissions. Use a PAT with contents:write
> Failed to process version v1.1.1: Resource not accessible by integration: 403

The workflow has no `permissions:` block, so it runs with the now-default read-only `GITHUB_TOKEN` and cannot create release tags. This adds the standard permissions block from the JuliaRegistries/TagBot README (`contents: write` is the operative grant).

No action needed after merging: TagBot's periodic retries on the trigger issue will pick up and tag the missed v1.1.1/v1.1.2 releases.

Context: verifying the repo was green after the trim-compile workload landed in #7 — all test CI is passing; TagBot was the only red workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)