### PR TITLE
Comprehensive correctness/robustness pass: parsers, iterators, Store API, crypt

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Figgy"
 uuid = "937e9308-674a-48ca-a404-047094c8c902"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,6 +59,22 @@ by doing subsequent loads. This follows the common pattern seen in applications 
 we want to do a prioritized load from a number of potential config sources, then later during normal runtime
 have the ability to tweak specific config values (like production log level) as needed.
 
+In addition to loading, `Figgy.Store` supports the familiar dict-like operations, all threadsafe:
+
+```julia
+store["key"]                     # current value for "key"; throws KeyError if absent
+get(store, "key", "default")     # current value or default
+get(() -> "computed", store, "key") # current value or computed fallback
+store["key"] = "value"           # manually set a value (recorded with a "manual" source)
+haskey(store, "key")
+length(store); isempty(store)
+keys(store); values(store)       # snapshots of current keys/values
+for (k, v) in store; ...; end    # iterate a snapshot of current key-value pairs
+delete!(store, "key")            # remove a config item (including history)
+empty!(store)                    # remove all config items
+Figgy.getfig(store, "key")       # full Figgy.Fig with value/source history
+```
+
 See the API Reference page for the section on builtin configuration sources provided directly by Figgy.jl,
  including program arguments, environment variales, ini files, json, xml, and toml.
 

--- a/src/Figgy.jl
+++ b/src/Figgy.jl
@@ -177,6 +177,59 @@ function Base.get(store::Store, key::String, default=nothing)
     end
 end
 
+"Get the current value for a config item identified by `key`, returns `f()` if not found"
+function Base.get(f::Base.Callable, store::Store, key::String)
+    Base.@lock store.lock begin
+        st = store.store
+        !haskey(st, key) && return f()
+        fig = st[key]
+        @assert !isempty(fig.values)
+        return fig.values[end]
+    end
+end
+
+"""
+    store[key] = value
+
+Manually set the current value for a config item identified by `key`.
+The update is recorded in the config item's history with a `Figgy.NamedSource("manual")` source.
+To load config items from sources in bulk, see [`Figgy.load!`](@ref).
+"""
+function Base.setindex!(store::Store, value, key::String)
+    Base.@lock store.lock begin
+        fig = get!(() -> Fig(key, Any[], FigSource[]), store.store, key)
+        update!(fig, value, NamedSource("manual"))
+    end
+    return store
+end
+
+"Number of config items currently in a `Figgy.Store`"
+Base.length(store::Store) = Base.@lock store.lock length(store.store)
+
+"Whether a `Figgy.Store` contains no config items"
+Base.isempty(store::Store) = Base.@lock store.lock isempty(store.store)
+
+"Snapshot of the config item keys currently in a `Figgy.Store`"
+Base.keys(store::Store) = Base.@lock store.lock collect(keys(store.store))
+
+"Snapshot of the current config item values in a `Figgy.Store`"
+Base.values(store::Store) = Base.@lock store.lock Any[fig.values[end] for fig in values(store.store)]
+
+Base.eltype(::Type{Store}) = Pair{String, Any}
+# SizeUnknown since the store may be mutated concurrently while iterating
+Base.IteratorSize(::Type{Store}) = Base.SizeUnknown()
+
+"Iterate `key => value` pairs of current config items (a snapshot taken when iteration starts)"
+function Base.iterate(store::Store)
+    snap = Base.@lock store.lock Pair{String, Any}[Pair{String, Any}(k, fig.values[end]) for (k, fig) in store.store]
+    return iterate(store, (snap, 1))
+end
+
+function Base.iterate(::Store, (snap, i))
+    i > length(snap) && return nothing
+    return snap[i], (snap, i + 1)
+end
+
 "Get the full `Figgy.Fig` object for a config item identified by `key`, throws `KeyError` if not found; includes history of values/sources"
 function getfig(store::Store, key::String)
     Base.@lock store.lock begin
@@ -233,7 +286,7 @@ function load!(store::Store, sources...; name::String="", log::Bool=true)
             for (k, v) in _pairs(source)
                 key = string(k)
                 if !(key in seen)
-                    log && @info "loading config property `$k` from `$(typeof(src))`"
+                    log && @info "loading config property `$k` from `$src`"
                     push!(seen, key)
                     entry = Pair{String, Tuple{Any, FigSource}}(key, (v, src))
                     push!(figs, entry)
@@ -282,8 +335,9 @@ kmap(source, mappings::Pair{String}...; select::Bool=false) = KeyMap(source, Dic
 kmap(source, mappings::Union{Function, Dict{String}}; select::Bool=false) = KeyMap(source, mappings, select)
 load(x::KeyMap) = x
 
-Base.IteratorSize(::Type{KeyMap{T, M}}) where {T, M} = Base.IteratorSize(T)
-Base.length(x::KeyMap) = length(x.source)
+# SizeUnknown since `select=true` filters keys, so the source length is only an upper bound
+Base.IteratorSize(::Type{<:KeyMap}) = Base.SizeUnknown()
+Base.IteratorEltype(::Type{<:KeyMap}) = Base.EltypeUnknown()
 
 Base.iterate(x::KeyMap) = _iterate(x, load(x.source))
 Base.iterate(x::KeyMap, (source, st)) = _iterate(x, source, st)
@@ -295,15 +349,18 @@ _keymap_key(key, key2::Function) = key2(key)
 _keymap_key(key, key2) = key === key2 ? key : key2
 function _iterate(x::KeyMap, source, st...)
     state = iterate(source, st...)
-    state === nothing && return nothing
-    kv, stt = state
-    key = kv[1]
-    if x.select && !_keymap_selected(x.mapping, key)
-        return _iterate(x, source, stt)
+    while true
+        state === nothing && return nothing
+        kv, stt = state
+        key = kv[1]
+        if x.select && !_keymap_selected(x.mapping, key)
+            state = iterate(source, stt)
+            continue
+        end
+        key2 = _keymap_value(x.mapping, key)
+        kv2 = _keymap_key(key, key2) => kv[2]
+        return kv2, (source, stt)
     end
-    key2 = _keymap_value(x.mapping, key)
-    kv2 = _keymap_key(key, key2) => kv[2]
-    return kv2, (source, stt)
 end
 
 struct Select{T, S} <: FigSource
@@ -325,8 +382,9 @@ select(source, keys::String...) = Select(source, Set(keys))
 select(source, filt) = Select(source, filt)
 load(x::Select) = x
 
-Base.IteratorSize(::Type{Select{T, S}}) where {T, S} = Base.IteratorSize(T)
-Base.length(x::Select) = length(x.source)
+# SizeUnknown since keys are filtered, so the source length is only an upper bound
+Base.IteratorSize(::Type{<:Select}) = Base.SizeUnknown()
+Base.IteratorEltype(::Type{<:Select}) = Base.EltypeUnknown()
 
 Base.iterate(x::Select) = _iterate(x, load(x.source))
 Base.iterate(x::Select, (source, st)) = _iterate(x, source, st)
@@ -334,12 +392,15 @@ _selected(set::Set, key) = key in set
 _selected(f::Function, key) = f(key)
 function _iterate(x::Select, source, st...)
     state = iterate(source, st...)
-    state === nothing && return nothing
-    kv, stt = state
-    if !_selected(x.set, kv[1])
-        return _iterate(x, source, stt)
+    while true
+        state === nothing && return nothing
+        kv, stt = state
+        if !_selected(x.set, kv[1])
+            state = iterate(source, stt)
+            continue
+        end
+        return kv, (source, stt)
     end
-    return kv, (source, stt)
 end
 
 include("sources.jl")

--- a/src/crypt.jl
+++ b/src/crypt.jl
@@ -84,7 +84,7 @@ function CipherConfig(;
     algorithm = _normalize_algorithm(algorithm)
     digest = _normalize_digest(digest)
     iterations = Int(iterations)
-    iterations >= 1 || throw(ArgumentError("iterations must be >= 1"))
+    1 <= iterations <= MAX_PARSED_ITERATIONS || throw(ArgumentError("iterations must be between 1 and $MAX_PARSED_ITERATIONS"))
     salt_bytes = Int(salt_bytes)
     salt_bytes >= 1 || throw(ArgumentError("salt_bytes must be >= 1"))
     key_bytes = something(key_bytes, _default_key_bytes(algorithm)) |> Int
@@ -128,15 +128,19 @@ function jasypt_config(; iterations::Integer=50_000)
 end
 
 """
-    Figgy.Crypt.encrypt(secret, plaintext; config=Figgy.Crypt.DEFAULT_CONFIG, key_id=nothing, aad=UInt8[], rng=Random.default_rng(), salt=nothing, iv=nothing, wrap=nothing)
+    Figgy.Crypt.encrypt(secret, plaintext; config=Figgy.Crypt.DEFAULT_CONFIG, key_id=nothing, aad=UInt8[], rng=Random.RandomDevice(), salt=nothing, iv=nothing, wrap=nothing)
 
 Encrypt a string or byte vector with a password/secret string or byte vector.
 
 The default returns a self-describing `ENC[figgy-v1](...)` value. Passing
 `key_id` stores an explicit key identifier in the envelope so decryptors can
 route to the correct key without trying keys by exception.
+
+Random salt/iv bytes are drawn from `Random.RandomDevice()` (the OS
+cryptographically-secure entropy source) by default; pass `rng`, or explicit
+`salt`/`iv` bytes, to override (e.g. for reproducible tests).
 """
-function encrypt(secret, plaintext; config::CipherConfig=DEFAULT_CONFIG, key_id::Union{Nothing,AbstractString}=nothing, aad=UInt8[], rng::AbstractRNG=Random.default_rng(), salt=nothing, iv=nothing, wrap=nothing)
+function encrypt(secret, plaintext; config::CipherConfig=DEFAULT_CONFIG, key_id::Union{Nothing,AbstractString}=nothing, aad=UInt8[], rng::AbstractRNG=Random.RandomDevice(), salt=nothing, iv=nothing, wrap=nothing)
     return _encrypt(secret, _bytes(plaintext), config, key_id, _bytes(aad), rng, salt, iv, wrap)
 end
 
@@ -176,14 +180,13 @@ Decrypt an encrypted string and return raw bytes.
 function decrypt_bytes(secret, encrypted::AbstractString; config::Union{Nothing,CipherConfig}=nothing, aad=UInt8[])
     envelope = parse_envelope(encrypted)
     aad = _bytes(aad)
-    if config === nothing
-        envelope.format == :figgy_v1 || throw(ArgumentError("config is required for non-Figgy encrypted values"))
+    # the self-describing Figgy payload takes precedence over any provided config:
+    # an explicit `ENC[figgy-v1](...)` envelope, or a bare/`ENC(...)` payload that
+    # begins with the Figgy magic bytes (e.g. a value encrypted with `wrap=false`)
+    if envelope.format == :figgy_v1 || _has_figgy_magic(envelope.payload)
         config, salt, iv, ciphertext, tag = _parse_figgy_payload(envelope.payload)
-    elseif config.envelope == :figgy_v1
-        config, salt, iv, ciphertext, tag = _parse_figgy_payload(envelope.payload)
-    elseif config.envelope == :jasypt
-        salt, iv, ciphertext = _parse_salt_iv_ciphertext(envelope.payload, config)
-        tag = UInt8[]
+    elseif config === nothing
+        throw(ArgumentError("config is required for non-Figgy encrypted values"))
     else
         salt, iv, ciphertext = _parse_salt_iv_ciphertext(envelope.payload, config)
         tag = UInt8[]
@@ -191,6 +194,8 @@ function decrypt_bytes(secret, encrypted::AbstractString; config::Union{Nothing,
     key = derive_key(secret, salt; config=config)
     return _evp_decrypt(config, key, iv, ciphertext, tag, aad)
 end
+
+_has_figgy_magic(payload::Vector{UInt8}) = length(payload) >= length(FIGGY_MAGIC) && payload[1:length(FIGGY_MAGIC)] == FIGGY_MAGIC
 
 """
     Figgy.Crypt.derive_key(secret, salt; config=Figgy.Crypt.DEFAULT_CONFIG)
@@ -324,6 +329,10 @@ function _encode_figgy_payload(config::CipherConfig, salt, iv, ciphertext, tag)
     return payload
 end
 
+# upper bound on PBKDF2 iterations accepted from (untrusted) encrypted payloads;
+# prevents a crafted envelope from claiming ~4 billion iterations and stalling decrypt
+const MAX_PARSED_ITERATIONS = 10_000_000
+
 function _parse_figgy_payload(payload::Vector{UInt8})
     minlen = length(FIGGY_MAGIC) + 12
     length(payload) >= minlen || throw(InvalidCiphertextError("Figgy encrypted payload is too short"))
@@ -332,6 +341,7 @@ function _parse_figgy_payload(payload::Vector{UInt8})
     algorithm = _algorithm_from_id(payload[pos])
     digest = _digest_from_id(payload[pos + 1])
     iterations = _read_u32(payload, pos + 2)
+    1 <= iterations <= MAX_PARSED_ITERATIONS || throw(InvalidCiphertextError("Figgy encrypted payload iteration count out of bounds: $iterations"))
     key_bytes = Int(payload[pos + 6])
     salt_bytes = Int(payload[pos + 7])
     iv_bytes = Int(payload[pos + 8])
@@ -476,7 +486,7 @@ function _openssl_error()
     code == 0 && return "OpenSSL returned no error detail"
     buf = Vector{UInt8}(undef, 256)
     ccall((:ERR_error_string_n, LIBCRYPTO), Cvoid, (Culong, Ptr{UInt8}, Csize_t), code, buf, length(buf))
-    return unsafe_string(pointer(buf))
+    return GC.@preserve buf unsafe_string(pointer(buf))
 end
 
 function _cipher(algorithm::Symbol)

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -7,13 +7,18 @@ end
 
 A FigSource that parses command line arguments to a Julia program.
 Specifically, arguments of the following form are parsed:
-  * `--key=value`, long-form argument that is parsed as `key => value`
+  * `--key=value`, long-form argument that is parsed as `key => value`;
+    the value may itself contain `=` characters (only the first `=` delimits)
+  * `--key`, long-form "flag" argument that is parsed as `key => "true"`
   * `-x`, "flag" argument that is parsed as `x => "true"`
   * `-abc`, multiple flag arguments that result in multiple key value pairs
     of the form `a => "true", b => "true", c => "true"`
   * `-x val`, required argument that is parsed as `x => val`
   * `-xval`, required argument that is parsed as `x => "val"` only when `"x"`
     is passed as a `requiredArgs` like `ProgramArguments("x")`
+
+Parsing stops at the first non-option argument, at a bare `-`, or at the
+conventional `--` end-of-options terminator.
 
 To transform program argument keys, see [`Figgy.kmap`](@ref).
 """
@@ -23,11 +28,21 @@ function ProgramArguments(requiredArgs::String...; args=ARGS)
     i = 1
     while i <= length(args)
         arg = args[i]
-        if startswith(arg, "--")
+        if arg == "--" || arg == "-"
+            # `--` is the conventional end-of-options terminator; a bare `-`
+            # conventionally means stdin and is treated as a non-option argument
+            break
+        elseif startswith(arg, "--")
             # long-form
-            spl = split(arg, "=")
-            length(spl) == 2 || throw(ArgumentError("invalid long-form program argument: `$arg`, expected of the form `--key=value`"))
-            push!(parsed, lstrip(spl[1], '-') => spl[2])
+            spl = split(arg, '='; limit=2)
+            key = lstrip(spl[1], '-')
+            isempty(key) && throw(ArgumentError("invalid long-form program argument: `$arg`, expected of the form `--key=value` or `--key`"))
+            if length(spl) == 2
+                push!(parsed, key => spl[2])
+            else
+                # long-form boolean flag like `--verbose`
+                push!(parsed, key => "true")
+            end
         elseif startswith(arg, "-")
             if length(arg) == 2 && i < length(args) && !startswith(args[i + 1], "-")
                 # short-form with value
@@ -71,6 +86,17 @@ EnvironmentVariables(env::Base.EnvDict=ENV) = EnvironmentVariables([k => v for (
 Base.show(io::IO, x::EnvironmentVariables) = print(io, "Figgy.EnvironmentVariables($(length(x.env) == 1 ? "1 entry" : "$(length(x.env)) entries"))")
 load(x::EnvironmentVariables) = x.env
 
+# treat `x` as a file path if it names an existing file, otherwise as the contents itself
+function _filecontents(x::AbstractString)
+    isfilepath = false
+    try
+        isfilepath = !occursin('\n', x) && isfile(x)
+    catch
+        # not a valid path (too long, embedded NULs, etc.); treat as contents
+    end
+    return isfilepath ? read(x, String) : String(x)
+end
+
 # INI files
 """
     Figgy.IniFile(file, section)
@@ -78,7 +104,9 @@ load(x::EnvironmentVariables) = x.env
 A FigSource that parses an INI file. The `file` argument can be a path
 to the INI file, or a `String` that is the contents of the INI file.
 The `section` argument is required and specifies the INI file section
-that will be parsed for key-value pairs.
+that will be parsed for key-value pairs. Within a section, each line is
+split on the first `=` or `:` (whichever comes first), so values may
+themselves contain separator characters; lines with no separator are ignored.
 """
 struct IniFile <: FigSource
     file::String
@@ -88,7 +116,7 @@ end
 # convenience interface for parsing a specific section of an INI file
 # returning key-values of that section
 function load(ini::IniFile)
-    contents = isfile(ini.file) ? read(ini.file, String) : ini.file
+    contents = _filecontents(ini.file)
     section = ini.section
     figs = Dict{String, String}()
     section = "[$section]"
@@ -101,14 +129,14 @@ function load(ini::IniFile)
             elseif startswith(line, "[") && endswith(line, "]")
                 break
             else
-                if contains(line, "=")
-                    k, v = split(line, "=")
-                elseif contains(line, ":")
-                    k, v = split(line, ":")
-                else
-                    # malformed line? skip
-                end
-                figs[strip(k)] = strip(v)
+                # split on the first `=` or `:`, whichever comes first,
+                # so values may contain separator characters (base64, urls, etc.)
+                eq = findfirst(isequal('='), line)
+                co = findfirst(isequal(':'), line)
+                sep = eq === nothing ? co : (co === nothing ? eq : min(eq, co))
+                # skip malformed lines with no key-value separator
+                sep === nothing && continue
+                figs[strip(line[1:prevind(line, sep)])] = strip(line[nextind(line, sep):end])
             end
         elseif line == section
             insection = true
@@ -121,9 +149,13 @@ end
     Figgy.JsonObject(json, path="")
 
 A FigSource for parsing simple json as key-value pairs. The `json` argument
-must be a `String` which is itself json data, or a `Vector{UInt8}`.
+can be a path to a json file, a `String` which is itself json data, or a
+`Vector{UInt8}` of json data.
 The json is expected to be a json object where the key-values will be considered
-key-value config pairs. The `path` argument is optional and is used to
+key-value config pairs. String values may contain standard json escape
+sequences (`\\"`, `\\\\`, `\\/`, `\\b`, `\\f`, `\\n`, `\\r`, `\\t`, and `\\uXXXX`),
+which are unescaped. Note that json array values are not supported.
+The `path` argument is optional and is used to
 specify a nested path to an object that should be used for config pairs. So a
 json object like:
 ```json
@@ -172,13 +204,100 @@ end
 
 numberbyte(b) = b == UInt8('-') || b == UInt8('+') || b == UInt8('.') || b == UInt8('e') || b == UInt8('E') || UInt8('0') <= b <= UInt8('9')
 
+# parse 4 hex digits at `pos`; all digits must lie strictly before `endpos`
+function _hex4(buf, pos, endpos)
+    pos + 3 < endpos || throw(ArgumentError("invalid json string: truncated \\u escape"))
+    u = UInt32(0)
+    for j = 0:3
+        b = getbyte(buf, pos + j)
+        d = UInt8('0') <= b <= UInt8('9') ? b - UInt8('0') :
+            UInt8('a') <= b <= UInt8('f') ? b - UInt8('a') + 0x0a :
+            UInt8('A') <= b <= UInt8('F') ? b - UInt8('A') + 0x0a :
+            throw(ArgumentError("invalid json string: invalid \\u escape digit"))
+        u = (u << 4) | d
+    end
+    return u
+end
+
+# read a json string starting at the opening quote at `pos`;
+# returns the position after the closing quote and the (unescaped) string
+function readstring(buf, pos, len)
+    pos += 1
+    startpos = pos
+    hasescape = false
+    while true
+        pos > len && throw(EOFError())
+        b = getbyte(buf, pos)
+        if b == UInt8('\\')
+            hasescape = true
+            pos += 2
+        elseif b == UInt8('"')
+            break
+        else
+            pos += 1
+        end
+    end
+    endpos = pos # position of the closing quote
+    hasescape || return endpos + 1, unsafe_string(pointer(buf, startpos), endpos - startpos)
+    out = IOBuffer()
+    i = startpos
+    while i < endpos
+        b = getbyte(buf, i)
+        if b != UInt8('\\')
+            write(out, b)
+            i += 1
+            continue
+        end
+        e = getbyte(buf, i + 1)
+        i += 2
+        if e == UInt8('"') || e == UInt8('\\') || e == UInt8('/')
+            write(out, e)
+        elseif e == UInt8('b')
+            write(out, UInt8('\b'))
+        elseif e == UInt8('f')
+            write(out, UInt8('\f'))
+        elseif e == UInt8('n')
+            write(out, UInt8('\n'))
+        elseif e == UInt8('r')
+            write(out, UInt8('\r'))
+        elseif e == UInt8('t')
+            write(out, UInt8('\t'))
+        elseif e == UInt8('u')
+            u = _hex4(buf, i, endpos)
+            i += 4
+            if 0xd800 <= u <= 0xdbff
+                # high surrogate; must be followed by an escaped low surrogate
+                (i + 1 < endpos && getbyte(buf, i) == UInt8('\\') && getbyte(buf, i + 1) == UInt8('u')) ||
+                    throw(ArgumentError("invalid json string: unpaired surrogate \\u escape"))
+                u2 = _hex4(buf, i + 2, endpos)
+                0xdc00 <= u2 <= 0xdfff || throw(ArgumentError("invalid json string: unpaired surrogate \\u escape"))
+                i += 6
+                u = UInt32(0x10000) + ((u - UInt32(0xd800)) << 10) + (u2 - UInt32(0xdc00))
+            elseif 0xdc00 <= u <= 0xdfff
+                throw(ArgumentError("invalid json string: unpaired surrogate \\u escape"))
+            end
+            write(out, Char(u))
+        else
+            throw(ArgumentError("invalid json string escape sequence: `\\$(Char(e))`"))
+        end
+    end
+    return endpos + 1, String(take!(out))
+end
+
 function readvalue(buf, pos, len, b)
     if b == UInt8('{')
         root = Dict{String, Any}()
         pos += 1
+        firstkey = true
         while true
             @nextbyte
             # @show Char(b)
+            if firstkey && b == UInt8('}')
+                # empty object
+                pos += 1
+                break
+            end
+            firstkey = false
             b == UInt8('"') || throw(ArgumentError("invalid json object for Figgy.JsonObject config source: expected opening key quote character; $(Char(b))"))
             pos, key = readvalue(buf, pos, len, b)
             @nextbyte
@@ -204,20 +323,7 @@ function readvalue(buf, pos, len, b)
     elseif b == UInt8('[')
         throw(ArgumentError("array values not supported by Figgy.JsonObject for config source"))
     elseif b == UInt8('"')
-        pos += 1
-        startpos = pos
-        while true
-            @nextbyte(false)
-            if b == UInt8('\\')
-                throw(ArgumentError("escape sequences in strings not supported by Figgy.JsonObject for config source"))
-            elseif b == UInt8('"')
-                pos += 1
-                break
-            end
-            pos += 1
-            @nextbyte(false)
-        end
-        return pos, unsafe_string(pointer(buf, startpos), pos - startpos - 1)
+        return readstring(buf, pos, len)
     elseif pos + 3 <= length(buf) &&
         b            == UInt8('n') &&
         buf[pos + 1] == UInt8('u') &&
@@ -251,7 +357,7 @@ source(x::AbstractVector{UInt8}) = x
 source(x::AbstractString) = codeunits(x)
 
 function JsonObject(json::Union{AbstractString, AbstractVector{UInt8}}, path::String="")
-    buf = source(json)
+    buf = json isa AbstractString ? source(_filecontents(json)) : source(json)
     pos = 1
     len = length(buf)
     @nextbyte
@@ -269,7 +375,11 @@ end
     Figgy.XmlObject(xml, path="")
 
 A FigSource for parsing simple xml as key-value pairs. The `xml` argument
-must be a `String` which is itself xml data, or a `Vector{UInt8}`.
+can be a path to an xml file, a `String` which is itself xml data, or a
+`Vector{UInt8}` of xml data.
+Xml declarations (`<?xml ...?>`), comments (`<!-- ... -->`), and doctypes
+are skipped; self-closing tags like `<key/>` are parsed as `key => ""`.
+Element text values have surrounding whitespace trimmed.
 The xml is expected to be a xml object where the key-values will be considered
 key-value config pairs. The `path` argument is optional and is used to
 specify a nested path to an object that should be used for config pairs. So a
@@ -296,10 +406,11 @@ end
 load(x::XmlObject) = x.figs
 
 function XmlObject(xml::Union{AbstractString, AbstractVector{UInt8}}, path::String="")
-    buf = source(xml)
+    buf = xml isa AbstractString ? source(_filecontents(xml)) : source(xml)
     pos = 1
     len = length(buf)
-    @nextbyte
+    pos = _skip_xml_misc(buf, pos, len)
+    b = getbyte(buf, pos)
     b == UInt8('<') || throw(ArgumentError("invalid xml; missing opening tag '<'"))
     pos, (rootkey, root) = readxml(buf, pos, len, b)
     if !isempty(path)
@@ -310,67 +421,131 @@ function XmlObject(xml::Union{AbstractString, AbstractVector{UInt8}}, path::Stri
     return XmlObject(root)
 end
 
+_xml_whitespace(b) = b == UInt8(' ') || b == UInt8('\t') || b == UInt8('\n') || b == UInt8('\r')
+
+# skip whitespace, xml declarations/processing instructions (`<?...?>`),
+# comments (`<!--...-->`), and doctypes (`<!...>`);
+# returns the position of the next content byte
+function _skip_xml_misc(buf, pos, len)
+    while true
+        while true
+            pos > len && throw(EOFError())
+            _xml_whitespace(getbyte(buf, pos)) || break
+            pos += 1
+        end
+        b = getbyte(buf, pos)
+        if b == UInt8('<') && pos < len && getbyte(buf, pos + 1) == UInt8('?')
+            # declaration/processing instruction; skip past `?>`
+            pos += 2
+            while true
+                pos >= len && throw(EOFError())
+                if getbyte(buf, pos) == UInt8('?') && getbyte(buf, pos + 1) == UInt8('>')
+                    pos += 2
+                    break
+                end
+                pos += 1
+            end
+        elseif b == UInt8('<') && pos + 3 <= len && getbyte(buf, pos + 1) == UInt8('!') && getbyte(buf, pos + 2) == UInt8('-') && getbyte(buf, pos + 3) == UInt8('-')
+            # comment; skip past `-->`
+            pos += 4
+            while true
+                pos + 2 > len && throw(EOFError())
+                if getbyte(buf, pos) == UInt8('-') && getbyte(buf, pos + 1) == UInt8('-') && getbyte(buf, pos + 2) == UInt8('>')
+                    pos += 3
+                    break
+                end
+                pos += 1
+            end
+        elseif b == UInt8('<') && pos < len && getbyte(buf, pos + 1) == UInt8('!')
+            # doctype or other declaration; skip past `>`
+            pos += 2
+            while true
+                pos > len && throw(EOFError())
+                if getbyte(buf, pos) == UInt8('>')
+                    pos += 1
+                    break
+                end
+                pos += 1
+            end
+        else
+            return pos
+        end
+    end
+end
+
+# match the element name at `keystartpos` (of length `keylen`) followed by `>`,
+# starting at `pos`; used for validating closing tags
+function _match_closing_tag(buf, pos, len, keystartpos, keylen, key)
+    for i = 0:(keylen - 1)
+        (pos <= len && getbyte(buf, pos) == getbyte(buf, keystartpos + i)) || throw(ArgumentError("malformed xml; expected closing tag for key: `$key`"))
+        pos += 1
+    end
+    (pos <= len && getbyte(buf, pos) == UInt8('>')) || throw(ArgumentError("malformed xml; expected closing tag for key: `$key`"))
+    return pos + 1
+end
+
 function readxml(buf, pos, len, b)
     pos += 1
     # parse key until space or closing tag
     keystartpos = pos
     foundspace = false
+    selfclosing = false
     keylen = 0
     while true
-        b = buf[pos]
+        pos > len && throw(EOFError())
+        b = getbyte(buf, pos)
         #TODO: handle escaped closing tags?
-        foundspace = foundspace || b == UInt8(' ')
-        b == UInt8('>') && break
-        keylen += !foundspace
+        if b == UInt8('>')
+            break
+        elseif b == UInt8('/') && pos < len && getbyte(buf, pos + 1) == UInt8('>')
+            selfclosing = true
+            foundspace = true
+        else
+            foundspace = foundspace || b == UInt8(' ')
+            keylen += !foundspace
+        end
         pos += 1
     end
     key = unsafe_string(pointer(buf, keystartpos), keylen)
     pos += 1
-    @nextbyte
-    if b == UInt8('<') && (pos < length(buf) && buf[pos + 1] != UInt8('/'))
+    # self-closing tag like `<key/>` has an empty string value
+    selfclosing && return pos, key => ""
+    pos = _skip_xml_misc(buf, pos, len)
+    b = getbyte(buf, pos)
+    if b == UInt8('<') && pos < len && getbyte(buf, pos + 1) != UInt8('/')
         # nested object
         val = Dict{String, Any}()
         while true
             pos, kv = readxml(buf, pos, len, b)
             val[kv.first] = kv.second
-            @nextbyte
-            if b == UInt8('<') && (pos < length(buf) && buf[pos + 1] == UInt8('/'))
-                pos += 2
-                for i = 0:(keylen - 1)
-                    buf[pos] == buf[keystartpos + i] || throw(ArgumentError("malformed xml; expected closing tag for key: `$key`"))
-                    pos += 1
-                end
-                b = buf[pos]
-                b == UInt8('>') || throw(ArgumentError("malformed xml; expected closing tag for key: `$key`"))
-                pos += 1
+            pos = _skip_xml_misc(buf, pos, len)
+            b = getbyte(buf, pos)
+            if b == UInt8('<') && pos < len && getbyte(buf, pos + 1) == UInt8('/')
+                pos = _match_closing_tag(buf, pos + 2, len, keystartpos, keylen, key)
                 break
             end
         end
         return pos, key => val
     else
-        # string value
+        # string value; leading whitespace was skipped above and
+        # trailing whitespace before the closing tag is trimmed
         strstartpos = pos
         strlen = 0
+        vallen = 0
         while true
-            b = buf[pos]
+            pos > len && throw(EOFError())
+            b = getbyte(buf, pos)
             if b == UInt8('<')
                 pos += 1
-                b = buf[pos]
-                b == UInt8('/') || throw(ArgumentError("malformed xml; expected closing tag for key: `$key`"))
-                pos += 1
-                for i = 0:(keylen - 1)
-                    buf[pos] == buf[keystartpos + i] || throw(ArgumentError("malformed xml; expected closing tag for key: `$key`"))
-                    pos += 1
-                end
-                b = buf[pos]
-                b == UInt8('>') || throw(ArgumentError("malformed xml: expected closing tag for key: `$key`"))
-                pos += 1
+                (pos <= len && getbyte(buf, pos) == UInt8('/')) || throw(ArgumentError("malformed xml; expected closing tag for key: `$key`"))
+                pos = _match_closing_tag(buf, pos + 1, len, keystartpos, keylen, key)
                 break
             end
             strlen += 1
+            _xml_whitespace(b) || (vallen = strlen)
             pos += 1
         end
-        str = unsafe_string(pointer(buf, strstartpos), strlen)
+        str = unsafe_string(pointer(buf, strstartpos), vallen)
         return pos, key => str
     end
 end

--- a/test/figgy_trim_safe.jl
+++ b/test/figgy_trim_safe.jl
@@ -29,6 +29,11 @@ function _trim_load_store()::Figgy.Store
         Figgy.ProgramArguments("p"; args = ["--mode=test", "-p8443", "-abc", "positional"]);
         log = false,
     )
+    Figgy.load!(
+        store,
+        Figgy.ProgramArguments(; args = ["--verbose", "--endpoint=http://host?a=b", "--", "--ignored=1"]);
+        log = false,
+    )
     return store
 end
 
@@ -37,6 +42,7 @@ function _trim_load_document_sources(store::Figgy.Store)::Nothing
     [default]
     region = us-west-2
     retries: 3
+    token = abc123==
     [other]
     region = us-east-1
     """
@@ -47,7 +53,9 @@ function _trim_load_document_sources(store::Figgy.Store)::Nothing
         "service": {
             "url": "https://example.invalid",
             "enabled": true,
-            "count": 2
+            "count": 2,
+            "quoted": "a \\"b\\" c",
+            "empty": {}
         },
         "unused": "ignored"
     }
@@ -55,10 +63,13 @@ function _trim_load_document_sources(store::Figgy.Store)::Nothing
     Figgy.load!(store, Figgy.JsonObject(json, "service"); log = false)
 
     xml = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!-- config sample -->
     <root>
         <database>
             <username>figgy</username>
             <password>secret</password>
+            <replica/>
         </database>
     </root>
     """
@@ -86,19 +97,37 @@ function run_figgy_trim_sample()::Nothing
     _trim_assert((store["a"]::String) == "true", "program flag a")
     _trim_assert((store["b"]::String) == "true", "program flag b")
     _trim_assert((store["c"]::String) == "true", "program flag c")
+    _trim_assert((store["verbose"]::String) == "true", "program long flag")
+    _trim_assert((store["endpoint"]::String) == "http://host?a=b", "program long value with =")
+    _trim_assert(!haskey(store, "ignored"), "program -- terminator")
     _trim_assert((store["region"]::String) == "us-west-2", "ini section")
     _trim_assert((store["retries"]::String) == "3", "ini colon")
+    _trim_assert((store["token"]::String) == "abc123==", "ini value with =")
     _trim_assert((store["url"]::String) == "https://example.invalid", "json string")
     _trim_assert((store["enabled"]::String) == "true", "json bool")
     _trim_assert((store["count"]::String) == "2", "json number")
+    _trim_assert((store["quoted"]::String) == "a \"b\" c", "json escaped string")
+    _trim_assert(isempty(store["empty"]::Dict{String, Any}), "json empty object")
     _trim_assert((store["username"]::String) == "figgy", "xml username")
     _trim_assert((store["password"]::String) == "secret", "xml password")
+    _trim_assert((store["replica"]::String) == "", "xml self-closing tag")
     _trim_assert((store["timeout"]::Int) == 30, "toml timeout")
     _trim_assert((store["burst"]::Int) == 4, "toml burst")
 
     fig = Figgy.getfig(store, "host")
     _trim_assert((fig[]::String) == "db.internal", "getfig")
     _trim_assert((get(store, "missing", "fallback")::String) == "fallback", "get fallback")
+    _trim_assert((get(() -> "computed", store, "missing")::String) == "computed", "get callable fallback")
+    _trim_assert(length(store) > 0, "length")
+    _trim_assert(!isempty(store), "isempty")
+    _trim_assert(length(keys(store)) == length(store), "keys snapshot")
+    store["manual"] = "42"
+    _trim_assert((store["manual"]::String) == "42", "setindex!")
+    n = 0
+    for kv in store
+        n += 1
+    end
+    _trim_assert(n == length(store), "iterate snapshot")
     delete!(store, "password")
     _trim_assert(!haskey(store, "password"), "delete")
     empty!(store)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,33 @@ using Base64, Figgy, Test
     @test !haskey(store, "key")
 end
 
+@testset "Figgy.Store dict-like API" begin
+    store = Figgy.Store()
+    @test isempty(store)
+    @test length(store) == 0
+    @test isempty(keys(store))
+    @test isempty(values(store))
+    @test collect(store) == Pair{String, Any}[]
+    @test get(() -> "computed", store, "missing") == "computed"
+
+    Figgy.load!(store, "a" => "1", "b" => "2"; log=false)
+    @test !isempty(store)
+    @test length(store) == 2
+    @test sort(keys(store)) == ["a", "b"]
+    @test sort(values(store)) == ["1", "2"]
+    @test sort(collect(store); by=first) == ["a" => "1", "b" => "2"]
+    @test get(() -> "computed", store, "a") == "1"
+
+    store["c"] = "3"
+    @test store["c"] == "3"
+    @test length(store) == 3
+    fig = Figgy.getfig(store, "c")
+    @test fig.sources[end] == Figgy.NamedSource("manual")
+    store["c"] = "4"
+    @test store["c"] == "4"
+    @test length(fig.values) == 2
+end
+
 @testset "Figgy.kmap" begin
     store = Figgy.Store()
     src = Dict("k" => "v", "k2" => "v2")
@@ -60,6 +87,20 @@ end
     Figgy.load!(store, Figgy.select(src, k -> (k == "k")))
     @test store["k"] == "v"
     @test !haskey(store, "k2")
+end
+
+@testset "Figgy.kmap/select iteration" begin
+    src = Dict("k" => "v", "k2" => "v2", "k3" => "v3")
+    # collect used to produce #undef entries when keys were filtered out
+    @test collect(Figgy.select(src, "k")) == ["k" => "v"]
+    @test collect(Figgy.kmap(src, "k" => "kk"; select=true)) == ["kk" => "v"]
+    @test sort(collect(Figgy.kmap(src, "k" => "kk"))) == ["k2" => "v2", "k3" => "v3", "kk" => "v"]
+    @test Base.IteratorSize(typeof(Figgy.select(src, "k"))) == Base.SizeUnknown()
+    @test Base.IteratorSize(typeof(Figgy.kmap(src, "k" => "kk"))) == Base.SizeUnknown()
+    # filtering out many consecutive keys used to blow the stack via recursion
+    bigsrc = Dict("key$i" => "v" for i = 1:200_000)
+    @test collect(Figgy.select(bigsrc, "nomatch")) == []
+    @test length(collect(Figgy.kmap(bigsrc, "key1" => "mapped"; select=true))) == 1
 end
 
 @testset "Figgy.Crypt" begin
@@ -105,6 +146,22 @@ end
     @test Figgy.decrypt("secret", jasypt_enc; config=jasypt) == "hello"
     @test Figgy.decrypt("secret", "ENC($jasypt_enc)"; config=jasypt) == "hello"
     @test_throws Figgy.Crypt.InvalidCiphertextError Figgy.decrypt("wrong", jasypt_enc; config=jasypt)
+
+    # a bare (wrap=false) figgy payload still round-trips without a config
+    bare = Figgy.encrypt("secret", "hello"; salt=salt, iv=iv, wrap=false)
+    @test !startswith(bare, "ENC")
+    @test Figgy.decrypt("secret", bare) == "hello"
+
+    # the self-describing figgy envelope wins over a mismatched explicit config
+    @test Figgy.decrypt("secret", enc; config=jasypt) == "hello"
+
+    # PBKDF2 iteration counts are bounded
+    @test_throws ArgumentError Figgy.Crypt.CipherConfig(; iterations=0)
+    @test_throws ArgumentError Figgy.Crypt.CipherConfig(; iterations=20_000_000)
+    # a crafted payload claiming ~4 billion iterations is rejected instead of stalling decrypt
+    crafted = copy(Figgy.Crypt.parse_envelope(enc).payload)
+    crafted[12:15] .= 0xff
+    @test_throws Figgy.Crypt.InvalidCiphertextError Figgy.decrypt("secret", "ENC[figgy-v1]($(base64encode(crafted)))")
 end
 
 @testset "Figgy.ProgramArguments" begin
@@ -133,6 +190,21 @@ end
     @test store["g"] == "val4"
     @test store["key5"] == "val5"
     @test store["h"] == "val6"
+
+    # long-form values may contain `=` characters
+    pa = Figgy.ProgramArguments(; args=["--url=http://host?a=b", "--token=abc=="])
+    @test pa.args == ["url" => "http://host?a=b", "token" => "abc=="]
+    # long-form boolean flags
+    pa = Figgy.ProgramArguments(; args=["--verbose", "--key=value"])
+    @test pa.args == ["verbose" => "true", "key" => "value"]
+    # `--` ends option parsing
+    pa = Figgy.ProgramArguments(; args=["--key=value", "--", "--notparsed=1"])
+    @test pa.args == ["key" => "value"]
+    # bare `-` (conventionally stdin) ends option parsing
+    pa = Figgy.ProgramArguments(; args=["-a", "-", "-b"])
+    @test pa.args == ["a" => "true"]
+    # empty long-form key is invalid
+    @test_throws ArgumentError Figgy.ProgramArguments(; args=["--=value"])
 end
 
 @testset "Figgy.EnvironmentVariables" begin
@@ -160,6 +232,30 @@ end
     Figgy.load!(store, Figgy.IniFile(ini, "named"))
     @test store["aws_access_key_id"] == "AKIAIOSFODNN7EXAMPLD"
     @test store["aws_secret_access_key"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEZ"
+
+    # values may contain separator characters; the first `=` or `:` delimits
+    ini2 = """
+    [default]
+    secret=abc123==
+    endpoint: http://localhost:8080
+    mixed = key:with=both
+    malformed line without separator
+    trailing=ok
+    """
+    figs = Figgy.load(Figgy.IniFile(ini2, "default"))
+    @test figs["secret"] == "abc123=="
+    @test figs["endpoint"] == "http://localhost:8080"
+    @test figs["mixed"] == "key:with=both"
+    @test figs["trailing"] == "ok"
+    @test length(figs) == 4
+
+    # a file path can be provided instead of contents
+    mktemp() do path, io
+        write(io, ini2)
+        close(io)
+        figs = Figgy.load(Figgy.IniFile(path, "default"))
+        @test figs["secret"] == "abc123=="
+    end
 end
 
 @testset "Figgy.JsonObject" begin
@@ -181,6 +277,31 @@ end
     Figgy.load!(store, Figgy.JsonObject(json, "key3"))
     @test store["key4"] == "value4"
     @test !haskey(store, "key")
+
+    # empty objects
+    @test Figgy.JsonObject("{}").figs == Dict{String, Any}()
+    @test Figgy.JsonObject(" { } ").figs == Dict{String, Any}()
+    nested = Figgy.JsonObject("""{"a": {}, "b": "c"}""")
+    @test nested.figs == Dict{String, Any}("a" => Dict{String, Any}(), "b" => "c")
+
+    # string escape sequences
+    escaped = Figgy.JsonObject("""{"k\\"1": "line1\\nline2", "k2": "a \\"quote\\" and \\\\ slash \\/ ok", "k3": "tab\\there", "k4": "\\u0041\\u00e9\\u4e2d", "k5": "\\ud834\\udd1e"}""")
+    @test escaped.figs["k\"1"] == "line1\nline2"
+    @test escaped.figs["k2"] == "a \"quote\" and \\ slash / ok"
+    @test escaped.figs["k3"] == "tab\there"
+    @test escaped.figs["k4"] == "Aé中"
+    @test escaped.figs["k5"] == "𝄞"
+    @test_throws ArgumentError Figgy.JsonObject("""{"k": "\\q"}""")
+    @test_throws ArgumentError Figgy.JsonObject("""{"k": "\\ud834"}""")
+    @test_throws ArgumentError Figgy.JsonObject("""{"k": "\\u12"}""")
+
+    # a file path can be provided instead of contents
+    mktemp() do path, io
+        write(io, json)
+        close(io)
+        j = Figgy.JsonObject(path, "key3")
+        @test j.figs["key4"] == "value4"
+    end
 end
 
 @testset "Figgy.XmlObject" begin
@@ -218,6 +339,40 @@ end
     Figgy.load!(store, Figgy.XmlObject(xml, "AssumeRoleResult.Credentials"))
     @test store["AccessKeyId"] == "ASIAIOSFODNN7EXAMPLE"
     @test store["SecretAccessKey"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY"
+    # multi-line text values have surrounding whitespace trimmed
+    @test endswith(store["SessionToken"], "R/oLxBA==")
+    @test !endswith(store["SessionToken"], "\n")
+
+    # xml declarations, comments, doctypes, and self-closing tags
+    xml2 = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE root>
+    <!-- top-level comment -->
+    <root>
+        <!-- comment between elements -->
+        <k>v</k>
+        <empty/>
+        <alsoempty attr="x"/>
+        <blank></blank>
+        <nested>
+            <inner>value</inner>
+        </nested>
+    </root>
+    """
+    x = Figgy.XmlObject(xml2)
+    @test x.figs["k"] == "v"
+    @test x.figs["empty"] == ""
+    @test x.figs["alsoempty"] == ""
+    @test x.figs["blank"] == ""
+    @test x.figs["nested"] == Dict{String, Any}("inner" => "value")
+
+    # a file path can be provided instead of contents
+    mktemp() do path, io
+        write(io, xml2)
+        close(io)
+        x = Figgy.XmlObject(path, "nested")
+        @test x.figs["inner"] == "value"
+    end
 end
 
 @testset "Figgy.TomlObject" begin


### PR DESCRIPTION
This PR is the result of a comprehensive review of the package for correctness, implementation gaps, bugs, performance issues, and traditionally-expected functionality. Every issue below was first confirmed with a runnable repro against `main`, then fixed with a regression test.

## Bugs fixed

### IniFile
- **Value truncation (data corruption):** lines were split on *every* `=`/`:`, so `secret=abc123==` loaded as `abc123` and `endpoint: http://localhost:8080` loaded as `http`. Lines now split on the *first* `=` or `:` (whichever comes first).
- **Crash on malformed lines:** a line with no separator hit an empty `else` branch and then used stale/undefined `k`/`v` — `UndefVarError` if first in section, silent corruption otherwise. Such lines are now skipped.
- **File-detection crash:** `isfile(contents)` throws `IOError: ENAMETOOLONG` on newer Julia for long single-line contents; path detection is now guarded.

### ProgramArguments
- `--url=http://x?a=b` threw (`=` in value); now only the first `=` delimits.
- `--verbose` style long-form boolean flags threw; now parse as `verbose => "true"`.
- `--` now acts as the conventional end-of-options terminator (previously threw); bare `-` (stdin convention) stops option parsing instead of being silently swallowed.

### JsonObject
- `{}` (top-level or nested) threw; now yields an empty object.
- String escapes threw; standard JSON escapes (`\" \\ \/ \b \f \n \r \t \uXXXX` incl. surrogate pairs) are now unescaped in keys and values, with a fast path when no escape is present.
- Accepts a file path, consistent with `IniFile`/`TomlObject`.

### XmlObject
- `<?xml ...?>` declarations, `<!-- comments -->`, and doctypes broke parsing entirely (real-world XML like AWS responses commonly has these); all are now skipped.
- Self-closing tags (`<key/>`, with or without attributes) threw; now parse as `key => ""`.
- Text values now have trailing whitespace trimmed (leading was already skipped — the asymmetry meant multi-line values like session tokens carried trailing `\n `).
- Parsing is bounds-checked (`EOFError`/`ArgumentError` instead of `BoundsError` on malformed input).
- Accepts a file path.

### kmap/select iterators
- **StackOverflowError:** filtered iteration recursed per skipped key; e.g. `select` over a 200k-entry source overflowed the stack. Now a loop (kept trim-safe: the varargs splat happens once with concrete types).
- **`collect` corruption:** `IteratorSize` forwarded the *source's* `HasLength`, so `collect(select(...))` returned arrays with trailing `#undef` entries. Both now declare `SizeUnknown` (the misleading `length` methods are removed).

### Crypt
- Default salt/IV generation now uses `Random.RandomDevice()` (OS CSPRNG) instead of `Random.default_rng()` (Xoshiro, not cryptographically secure). `rng`/`salt`/`iv` kwargs still allow deterministic tests.
- The self-describing `figgy-v1` payload now takes precedence over a mismatched explicit `config`, and bare payloads produced with `wrap=false` round-trip through `decrypt` without a config (previously: confusing failures in both cases).
- PBKDF2 iteration counts parsed from (untrusted) payloads are bounded at 10M — a crafted envelope could previously claim ~4.3B iterations and stall `decrypt` for hours before auth failure. `CipherConfig` enforces the same bound for symmetry.
- `GC.@preserve` fix in `_openssl_error`.

## Expected functionality added

`Figgy.Store` now supports the dict-like API users expect, all locked/threadsafe: `length`, `isempty`, `keys`, `values`, `iterate` (snapshot-based), `setindex!` (recorded in history with a `NamedSource("manual")` source), and `get(f::Callable, store, key)`. Docs updated. The `load!` log message now shows the provided `name` for named sources instead of `Figgy.NamedSource`.

## Testing

- Test suite grew from 74 to 135 assertions; every fix has a regression test.
- Full suite green on Julia 1.12.6 (including the JuliaC `--trim=safe` workload, 7/7) and Julia 1.6.7 (135/135).
- The trim workload was extended to exercise the new paths (JSON escapes/empty objects, XML declaration/comment/self-closing, `--` terminator, Store dict API) and compiles trim-clean.

Version bumped to 1.3.0 (additive API + behavior fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)